### PR TITLE
Update zk-paillier dependency for fs-dkr updates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ subtle = { version = "2" }
 serde = { version = "1.0", features = ["derive"] }
 zeroize = "^1.5"
 curv-kzen = { version = "0.10.0", default-features = false }
-centipede = { git = "https://github.com/zengo-x/centipede.git", default-features = false }
+centipede = { version = "0.3.1", default-features = false }
 zk-paillier = { version = "0.4.4", default-features = false }
 round-based = { version = "0.1.4", features = [] }
 thiserror = "1.0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0", features = ["derive"] }
 zeroize = "^1.5"
 curv-kzen = { version = "0.10.0", default-features = false }
 centipede = { git = "https://github.com/zengo-x/centipede.git", default-features = false }
-zk-paillier = { git = "https://github.com/zengo-x/zk-paillier.git", default-features = false }
+zk-paillier = { version = "0.4.4", default-features = false }
 round-based = { version = "0.1.4", features = [] }
 thiserror = "1.0.23"
 derivative = "2.2.0"


### PR DESCRIPTION
Hi,

I am trying to compile your CGGMP work at https://github.com/webb-tools/cggmp-threshold-ecdsa/ for webassembly but running into issues as there are multiple versions of `curv` in the dependency tree which yields problems with the transient dependency `signature`.

Merging this PR will allow me to update `fs-dkr` to `curv:0.10`.